### PR TITLE
downgrade Conan

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -59,6 +59,8 @@ jobs:
 
       - name: Setup conan
         uses: turtlebrowser/get-conan@main
+        with:
+          version: 1.59.0
 
       - name: Setup ccache
         uses: hendrikmuhs/ccache-action@v1.2


### PR DESCRIPTION
New Conan version introduced braking changes so temporarily we must downgrade to version 1.59.0